### PR TITLE
Fixing bug with latest omada firmware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ COPY package*.json ./
 
 RUN npm install
 
-COPY *.js .
+COPY *.js ./
 
 CMD ["npm", "start"]

--- a/omada.js
+++ b/omada.js
@@ -185,7 +185,8 @@ class Omada {
         const localAnswers = {};
         for( let r of dhcpReservations ) {
             const names = [];
-            names.push( r.description );
+            if(r.description)
+                names.push( r.description );
             names.push( r.mac );
             if( r.clientName != r.mac )
                 names.push( r.clientName );


### PR DESCRIPTION
Description seems to be not a property in the result in latest omada firmware, made it optional. Also fixed a error in the Dockerfile, latest docker doesn't allow COPY command to paths that don't end with an /.